### PR TITLE
Drop pyifcb for ifcbkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ computed here are comparable with historical IFCB datasets.
 
 The package targets Python 3.10+ and depends on `numpy`, `scipy`,
 `scikit-image`, and `scikit-learn`, plus two WHOI packages installed directly
-from GitHub ([`pyifcb`](https://github.com/joefutrelle/pyifcb) for reading IFCB
+from GitHub ([`ifcbkit`](https://github.com/WHOIGit/ifcbkit) for reading IFCB
 data and [`phasepack`](https://github.com/WHOIGit/phasepack) for phase
 congruency used during segmentation).
 
@@ -40,14 +40,14 @@ pip install -e .
 ## Usage
 
 The main entry point is [`extract_slim_features.py`](extract_slim_features.py).
-It reads whole IFCB bins (via `pyifcb`), computes the per-ROI feature set, and
+It reads whole IFCB bins (via `ifcbkit`), computes the per-ROI feature set, and
 writes the results to disk:
 
 ```bash
 python extract_slim_features.py <data_directory> <output_directory> [--bins BIN1 BIN2 ...]
 ```
 
-- `data_directory` — directory of IFCB data (read via `pyifcb`).
+- `data_directory` — directory of IFCB data (read via `ifcbkit`).
 - `output_directory` — where the outputs are written.
 - `--bins` — optional list of bin names (e.g. `D20240423T115846_IFCB127`) to
   process; if omitted, every bin in the data directory is processed.

--- a/extract_slim_features.py
+++ b/extract_slim_features.py
@@ -1,6 +1,6 @@
 import argparse
 import csv
-from ifcb import DataDirectory
+from ifcbkit import SyncIfcbDataDirectory, parse_pid
 from ifcb_features import RoiFeatures
 import os
 import pandas as pd
@@ -57,11 +57,11 @@ def extract_and_save_all_features(data_directory, output_directory, bins=None):
         bins (list, optional): A list of bin names (e.g., 'D20240423T115846_IFCB127') to process.
             If None, all bins in the data directory are processed. Defaults to None.
     """
-    try:
-        data_dir = DataDirectory(data_directory)
-    except FileNotFoundError:
+    if not os.path.isdir(data_directory):
         print(f"Error: Data directory not found at '{data_directory}'.")
         return
+    try:
+        data_dir = SyncIfcbDataDirectory(data_directory)
     except Exception as e:
         print(f"Error loading data directory: {e}")
         return
@@ -72,27 +72,28 @@ def extract_and_save_all_features(data_directory, output_directory, bins=None):
         print(f"Error creating output directory '{output_directory}': {e}")
         return
 
-    samples_to_process = []
+    pids_to_process = []
     if bins:
         for bin_name in bins:
             try:
-                sample = data_dir[bin_name]
-                samples_to_process.append(sample)
-            except KeyError:
-                print(f"Warning: Bin '{bin_name}' not found in data directory. Skipping.")
+                if data_dir.exists(bin_name):
+                    pids_to_process.append(bin_name)
+                else:
+                    print(f"Warning: Bin '{bin_name}' not found in data directory. Skipping.")
             except Exception as e:
                 print(f"Error accessing bin '{bin_name}': {e}")
                 traceback.print_exc()
     else:
-        for sample in data_dir:
-            samples_to_process.append(sample)
+        for fileset in data_dir.list():
+            pids_to_process.append(fileset['pid'])
 
-    for sample in samples_to_process:
+    for pid in pids_to_process:
+        lid = parse_pid(pid)['lid']
         all_features = []
         all_blobs = {}
-        features_output_filename = os.path.join(output_directory, f"{sample.lid}_features_v4.csv")
-        blobs_output_filename = os.path.join(output_directory, f"{sample.lid}_blobs_v4.zip")
-        for number, image in sample.images.items():
+        features_output_filename = os.path.join(output_directory, f"{lid}_features_v4.csv")
+        blobs_output_filename = os.path.join(output_directory, f"{lid}_blobs_v4.zip")
+        for number, image in data_dir.read_images(pid).items():
             features = {
                 'roi_number': number,
             }
@@ -104,18 +105,18 @@ def extract_and_save_all_features(data_directory, output_directory, bins=None):
                 Image.fromarray((blobs_image > 0).astype(np.uint8) * 255).save(img_buffer, format="PNG")
                 all_blobs[number] = img_buffer.getvalue()
             except Exception as e:
-                print(f"Error processing ROI {number} in sample {sample.pid}: {e}")
+                print(f"Error processing ROI {number} in sample {pid}: {e}")
 
             all_features.append(features)
 
         if all_features:
             df = pd.DataFrame.from_records(all_features, columns=['roi_number'] + FEATURE_COLUMNS)
             df.to_csv(features_output_filename, index=False, float_format="%.10g")
-        
+
         if all_blobs:
             with zipfile.ZipFile(blobs_output_filename, 'w') as zf:
                 for roi_number, blob_data in all_blobs.items():
-                    filename = f"{sample.lid}_{roi_number:05d}.png"
+                    filename = f"{lid}_{roi_number:05d}.png"
                     zf.writestr(filename, blob_data)
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ifcb-features"
 version = "0.1.1"
 description = "IFCB feature extraction tools"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
     { name = "Joe Futrelle", email = "jfutrelle@whoi.edu" }
@@ -18,9 +18,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
@@ -30,7 +27,7 @@ dependencies = [
     "scikit-image",
     "phasepack @ git+https://github.com/WHOIGit/phasepack@v1.6.1",
     "scikit-learn",
-    "pyifcb @ git+https://github.com/joefutrelle/pyifcb@v1.2.1"
+    "ifcbkit @ git+https://github.com/joefutrelle/ifcbkit@main"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ifcb-features"
-version = "0.1.1"
+version = "0.2.0"
 description = "IFCB feature extraction tools"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,7 +27,7 @@ dependencies = [
     "scikit-image",
     "phasepack @ git+https://github.com/WHOIGit/phasepack@v1.6.1",
     "scikit-learn",
-    "ifcbkit @ git+https://github.com/joefutrelle/ifcbkit@main"
+    "ifcbkit @ git+https://github.com/joefutrelle/ifcbkit@v0.2.1"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ifcb-features"
-version = "0.2.0"
+version = "1.1.0"
 description = "IFCB feature extraction tools"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request updates the feature extraction script to use the new `ifcbkit` library instead of the older `pyifcb` dependency, and refactors how data directories and bins are handled. It also updates the minimum Python version requirement and cleans up the dependencies and supported Python versions in `pyproject.toml`.

**Migration to `ifcbkit` and refactoring:**

* Replaced imports and usage of `DataDirectory` from `pyifcb` with `SyncIfcbDataDirectory` and related utilities from `ifcbkit` in `extract_slim_features.py`.
* Refactored the logic for gathering and processing bins: now uses `data_dir.list()` and `data_dir.read_images(pid)` to iterate and process bins by their PID, improving compatibility with `ifcbkit`. [[1]](diffhunk://#diff-1b794e5a485e2e577e0873680773e7de1b7765d94df5b92399c31b7b0db5f5c6L60-R64) [[2]](diffhunk://#diff-1b794e5a485e2e577e0873680773e7de1b7765d94df5b92399c31b7b0db5f5c6L75-R96)
* Updated references from `sample` objects to using PIDs and LIDs for file naming and error messages, aligning with the new data access pattern. [[1]](diffhunk://#diff-1b794e5a485e2e577e0873680773e7de1b7765d94df5b92399c31b7b0db5f5c6L107-R108) [[2]](diffhunk://#diff-1b794e5a485e2e577e0873680773e7de1b7765d94df5b92399c31b7b0db5f5c6L118-R119)

**Dependency and environment updates:**

* Changed the required Python version to 3.10+ and removed support for earlier Python 3 versions in `pyproject.toml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21-L23)
* Replaced the dependency on `pyifcb` with `ifcbkit` in `pyproject.toml`.