### PR TITLE
fix scipy deprecation warnings

### DIFF
--- a/ifcb_features/all.py
+++ b/ifcb_features/all.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from scipy.ndimage.measurements import find_objects
+from scipy.ndimage import find_objects
 from scipy.spatial import QhullError
 
 from skimage.measure import label, regionprops

--- a/ifcb_features/blobs.py
+++ b/ifcb_features/blobs.py
@@ -1,13 +1,13 @@
 import numpy as np
 
-from scipy.ndimage import measurements
+from scipy.ndimage import find_objects, label
 
 from .morphology import SE2, SE3, EIGHT, bwmorph_thin
 
 def label_blobs(B):
     B = np.array(B).astype(bool)
-    labeled, _ = measurements.label(B,structure=EIGHT)
-    objects = measurements.find_objects(labeled)
+    labeled, _ = label(B, structure=EIGHT)
+    objects = find_objects(labeled)
     return labeled, objects
     
 def find_blobs(B):

--- a/ifcb_features/segmentation.py
+++ b/ifcb_features/segmentation.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from scipy.ndimage import label
-from scipy.ndimage.morphology import binary_fill_holes
+from scipy.ndimage import binary_fill_holes, label
 from skimage.morphology import closing, dilation, erosion, diamond
 import skimage.filters as imfilters
 


### PR DESCRIPTION
Updates deprecated SciPy ndimage imports to use the supported top-level scipy.ndimage namespace.